### PR TITLE
refactor: Move @0no-co/graphql.web to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,8 +58,10 @@
       "graphql": "~16.6.0"
     }
   },
+  "dependencies": {
+    "@0no-co/graphql.web": "^0.1.6"
+  },
   "devDependencies": {
-    "@0no-co/graphql.web": "^0.1.6",
     "@babel/core": "^7.21.3",
     "@rollup/plugin-babel": "^6.0.3",
     "@rollup/plugin-node-resolve": "^15.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,8 +34,9 @@ importers:
       sucrase: ^3.30.0
       typescript: ^5.0.2
       vitest: ^0.29.7
-    devDependencies:
+    dependencies:
       '@0no-co/graphql.web': 0.1.6
+    devDependencies:
       '@babel/core': 7.21.3
       '@rollup/plugin-babel': 6.0.3_a7epsyulyww3x7faazdjx6zxy4
       '@rollup/plugin-node-resolve': 15.0.1_rollup@3.20.1
@@ -86,7 +87,7 @@ packages:
 
   /@0no-co/graphql.web/0.1.6:
     resolution: {integrity: sha512-HUFsLTSjX6sTdK+CyoHNs71h0HneugTO6nQS8WwxFGarmAh3doKwZRVY39xLkdOmneSKJZIHRysjf+odHHBFhw==}
-    dev: true
+    dev: false
 
   /@ampproject/remapping/2.2.0:
     resolution: {integrity: sha512-qRmjj8nj9qmLTQXXmaR1cck3UXSRMPrbsLJAasZpF+t3riI71BXed5ebIOYwQntykeZuhjsdweEc9BxH5Jc26w==}

--- a/scripts/rollup/config.mjs
+++ b/scripts/rollup/config.mjs
@@ -20,7 +20,7 @@ const virtualModule = path.posix.join(cwd, 'virtual/');
 const aliasModule = path.posix.join(cwd, 'alias/');
 
 const EXTERNAL = 'graphql';
-const externalModules = ['dns', 'fs', 'path', 'url'];
+const externalModules = ['dns', 'fs', 'path', 'url', '@0no-co/graphql.web'];
 const externalPredicate = new RegExp(`^(${externalModules.join('|')})($|/)`);
 
 function manualChunks(id, utils) {


### PR DESCRIPTION
## Summary

This moves `@0no-co/graphql.web` from `devDependencies` to `dependencies` and marks it as `external` in our builds to make it reusable across more packages than just this one. 

## Set of changes

- Move `@0no-co/graphql.web` from `devDependencies` to `dependencies`
- Mark `@0no-co/graphql.web` as external in Rollup build
